### PR TITLE
Add the possibility to load custom modules

### DIFF
--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -7,6 +7,7 @@ import io.github.vhoyon.vramework.modules.*;
 
 import java.awt.GraphicsEnvironment;
 import java.io.*;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Date;
@@ -73,6 +74,9 @@ public class Framework {
 		
 		for(StackTraceElement stackElement : stackElements){
 			
+			if(stackElement == stackElements[0])
+				continue;
+			
 			if(!stackElement.getClassName().equals(
 					Framework.class.getCanonicalName())){
 				
@@ -98,7 +102,10 @@ public class Framework {
 			
 			List<String> allErrors = new ArrayList<>();
 			
-			allErrors.addAll(defaultModuleErrors);
+			if(shouldLoadDefaultModules){
+				allErrors.addAll(defaultModuleErrors);
+			}
+			allErrors.addAll(autoModuleErrors);
 			allErrors.addAll(moduleErrors);
 			
 			StringBuilder sb = new StringBuilder();

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -149,8 +149,7 @@ public class Framework {
 					defaultModuleToLoad.build();
 				}
 				catch(Exception e){
-					errors.add(defaultModuleToLoad.getLoadingErrorMessage(e)
-							+ "\n");
+					errors.add(defaultModuleToLoad.getLoadingErrorMessage(e));
 				}
 				
 			}
@@ -191,14 +190,14 @@ public class Framework {
 					moduleToLoad.build();
 				}
 				catch(Exception e){
-					errors.add(moduleToLoad.getLoadingErrorMessage(e) + "\n");
+					errors.add(moduleToLoad.getLoadingErrorMessage(e));
 				}
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
 				errors.add("Module \""
 						+ module.getCanonicalName()
-						+ "\" not found. Very odd considering this was an automatic action.");
+						+ "\" cannot be instanced. Make sure it has a public constructor with no arguments.");
 			}
 			
 		}
@@ -221,13 +220,19 @@ public class Framework {
 					moduleToLoad.build();
 				}
 				catch(Exception e){
-					errors.add(moduleToLoad.getLoadingErrorMessage(e) + "\n");
+					errors.add(moduleToLoad.getLoadingErrorMessage(e));
 				}
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
-				errors.add("Module \"" + module.getCanonicalName()
-						+ "\" not found.");
+				if(module.isAnonymousClass()){
+					errors.add("Cannot load anonymous modules. Please create a new class to be able to load it.");
+				}
+				else{
+					errors.add("Module \""
+							+ module.getCanonicalName()
+							+ "\" not found. Make sure it has a public constructor with no arguments.");
+				}
 			}
 			
 		}

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -138,7 +138,7 @@ public class Framework {
 			}
 			catch(InstantiationException | IllegalAccessException e){
 				errors.add("Module \"" + defaultModule.getCanonicalName()
-						+ "\" not found.");
+						+ "\" not found. The Framework needs an update...");
 			}
 			
 		}
@@ -161,7 +161,31 @@ public class Framework {
 			
 		}
 		
-		return loadModules(modules.toArray(new Class[0]));
+		List<String> errors = new ArrayList<>();
+		
+		for(Class<? extends Module> module : modules){
+			
+			try{
+				
+				Module moduleToLoad = module.newInstance();
+				
+				try{
+					moduleToLoad.build();
+				}
+				catch(Exception e){
+					errors.add(moduleToLoad.getLoadingErrorMessage(e) + "\n");
+				}
+				
+			}
+			catch(InstantiationException | IllegalAccessException e){
+				errors.add("Module \""
+						+ module.getCanonicalName()
+						+ "\" not found. Very odd considering this was an automatic action.");
+			}
+			
+		}
+		
+		return errors;
 		
 	}
 	

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -1,5 +1,7 @@
 package io.github.vhoyon.vramework;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 import io.github.vhoyon.vramework.abstracts.Module;
 import io.github.vhoyon.vramework.modules.*;
 
@@ -88,10 +90,11 @@ public class Framework {
 		if(shouldLoadDefaultModules){
 			defaultModuleErrors = loadDefaultModules();
 		}
+		List<String> autoModuleErrors = loadAutomaticModules();
 		List<String> moduleErrors = loadModules(modulesToLoad);
 		
 		if((defaultModuleErrors != null && defaultModuleErrors.size() > 0)
-				|| moduleErrors.size() > 0){
+				|| autoModuleErrors.size() > 0 || moduleErrors.size() > 0){
 			
 			List<String> allErrors = new ArrayList<>();
 			
@@ -110,7 +113,7 @@ public class Framework {
 		
 	}
 	
-	private static List<String> loadDefaultModules() throws RuntimeException{
+	private static List<String> loadDefaultModules(){
 		
 		List<String> errors = new ArrayList<>();
 		
@@ -144,8 +147,25 @@ public class Framework {
 		
 	}
 	
-	private static List<String> loadModules(Class<? extends Module>[] modules)
-			throws RuntimeException{
+	private static List<String> loadAutomaticModules(){
+		
+		String packageName = classRunIn.getPackage().getName() + ".modules";
+		
+		List<Class<Module>> modules;
+		
+		try(ScanResult results = new ClassGraph()
+				.whitelistPackages(packageName).scan()){
+			
+			modules = results.getSubclasses(Module.class.getCanonicalName())
+					.loadClasses(Module.class);
+			
+		}
+		
+		return loadModules(modules.toArray(new Class[0]));
+		
+	}
+	
+	private static List<String> loadModules(Class<? extends Module>[] modules){
 		
 		List<String> errors = new ArrayList<>();
 		

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -51,12 +51,12 @@ public class Framework {
 		final StackTraceElement[] stackElements = Thread.currentThread()
 				.getStackTrace();
 		
-		for(int i = 0; i < stackElements.length; i++){
+		for(StackTraceElement stackElement : stackElements){
 			
-			if(!stackElements[i].getClassName().equals(
+			if(!stackElement.getClassName().equals(
 					Framework.class.getCanonicalName())){
 				
-				Framework.classRunIn = Class.forName(stackElements[i]
+				Framework.classRunIn = Class.forName(stackElement
 						.getClassName());
 				break;
 				
@@ -65,6 +65,13 @@ public class Framework {
 		}
 		
 		Framework.setupGlobalVariables(isDebugging);
+		
+		loadDefaultModules();
+		loadModules(modulesToLoad);
+		
+	}
+	
+	private static void loadDefaultModules() throws RuntimeException{
 		
 		StringBuilder errors = new StringBuilder();
 		
@@ -88,13 +95,25 @@ public class Framework {
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
-				errors.append("Module \"").append(e.getMessage())
+				errors.append("Module \"")
+						.append(defaultModule.getCanonicalName())
 						.append("\" not found.").append("\n");
 			}
 			
 		}
 		
-		for(Class<? extends Module> module : modulesToLoad){
+		if(errors.length() != 0){
+			throw new RuntimeException(errors.toString());
+		}
+		
+	}
+	
+	private static void loadModules(Class<? extends Module>[] modules)
+			throws RuntimeException{
+		
+		StringBuilder errors = new StringBuilder();
+		
+		for(Class<? extends Module> module : modules){
 			
 			try{
 				
@@ -110,14 +129,14 @@ public class Framework {
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
-				errors.append("Module \"").append(e.getMessage())
+				errors.append("Module \"").append(module.getCanonicalName())
 						.append("\" not found.").append("\n");
 			}
 			
 		}
 		
 		if(errors.length() != 0){
-			throw new Exception(errors.toString());
+			throw new RuntimeException(errors.toString());
 		}
 		
 	}

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -3,10 +3,12 @@ package io.github.vhoyon.vramework;
 import io.github.vhoyon.vramework.abstracts.Module;
 import io.github.vhoyon.vramework.modules.*;
 
-import java.awt.*;
+import java.awt.GraphicsEnvironment;
 import java.io.*;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 public class Framework {
 	
@@ -66,14 +68,31 @@ public class Framework {
 		
 		Framework.setupGlobalVariables(isDebugging);
 		
-		loadDefaultModules();
-		loadModules(modulesToLoad);
+		List<String> defaultModuleErrors = loadDefaultModules();
+		List<String> moduleErrors = loadModules(modulesToLoad);
+		
+		if(defaultModuleErrors.size() > 0 || moduleErrors.size() > 0){
+			
+			List<String> allErrors = new ArrayList<>();
+			
+			allErrors.addAll(defaultModuleErrors);
+			allErrors.addAll(moduleErrors);
+			
+			StringBuilder sb = new StringBuilder();
+			
+			for(String error : allErrors){
+				sb.append(error).append("\n");
+			}
+			
+			throw new RuntimeException(sb.toString());
+			
+		}
 		
 	}
 	
-	private static void loadDefaultModules() throws RuntimeException{
+	private static List<String> loadDefaultModules() throws RuntimeException{
 		
-		StringBuilder errors = new StringBuilder();
+		List<String> errors = new ArrayList<>();
 		
 		for(Class<?> defaultModule : defaultModules){
 			
@@ -89,29 +108,26 @@ public class Framework {
 					defaultModuleToLoad.build();
 				}
 				catch(Exception e){
-					errors.append(defaultModuleToLoad.getLoadingErrorMessage(e))
-							.append("\n\n");
+					errors.add(defaultModuleToLoad.getLoadingErrorMessage(e)
+							+ "\n");
 				}
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
-				errors.append("Module \"")
-						.append(defaultModule.getCanonicalName())
-						.append("\" not found.").append("\n");
+				errors.add("Module \"" + defaultModule.getCanonicalName()
+						+ "\" not found.");
 			}
 			
 		}
 		
-		if(errors.length() != 0){
-			throw new RuntimeException(errors.toString());
-		}
+		return errors;
 		
 	}
 	
-	private static void loadModules(Class<? extends Module>[] modules)
+	private static List<String> loadModules(Class<? extends Module>[] modules)
 			throws RuntimeException{
 		
-		StringBuilder errors = new StringBuilder();
+		List<String> errors = new ArrayList<>();
 		
 		for(Class<? extends Module> module : modules){
 			
@@ -123,21 +139,18 @@ public class Framework {
 					moduleToLoad.build();
 				}
 				catch(Exception e){
-					errors.append(moduleToLoad.getLoadingErrorMessage(e))
-							.append("\n\n");
+					errors.add(moduleToLoad.getLoadingErrorMessage(e) + "\n");
 				}
 				
 			}
 			catch(InstantiationException | IllegalAccessException e){
-				errors.append("Module \"").append(module.getCanonicalName())
-						.append("\" not found.").append("\n");
+				errors.add("Module \"" + module.getCanonicalName()
+						+ "\" not found.");
 			}
 			
 		}
 		
-		if(errors.length() != 0){
-			throw new RuntimeException(errors.toString());
-		}
+		return errors;
 		
 	}
 	

--- a/src/main/java/io/github/vhoyon/vramework/Framework.java
+++ b/src/main/java/io/github/vhoyon/vramework/Framework.java
@@ -49,6 +49,22 @@ public class Framework {
 	
 	public static void build(boolean isDebugging,
 			Class<? extends Module>... modulesToLoad) throws Exception{
+		Framework.build(isDebugging, true, modulesToLoad);
+	}
+	
+	public static void buildClean(Class<? extends Module>... modulesToLoad)
+			throws Exception{
+		Framework.buildClean(false, modulesToLoad);
+	}
+	
+	public static void buildClean(boolean isDebugging,
+			Class<? extends Module>... modulesToLoad) throws Exception{
+		Framework.build(isDebugging, false, modulesToLoad);
+	}
+	
+	public static void build(boolean isDebugging,
+			boolean shouldLoadDefaultModules,
+			Class<? extends Module>... modulesToLoad) throws Exception{
 		
 		final StackTraceElement[] stackElements = Thread.currentThread()
 				.getStackTrace();
@@ -68,10 +84,14 @@ public class Framework {
 		
 		Framework.setupGlobalVariables(isDebugging);
 		
-		List<String> defaultModuleErrors = loadDefaultModules();
+		List<String> defaultModuleErrors = null;
+		if(shouldLoadDefaultModules){
+			defaultModuleErrors = loadDefaultModules();
+		}
 		List<String> moduleErrors = loadModules(modulesToLoad);
 		
-		if(defaultModuleErrors.size() > 0 || moduleErrors.size() > 0){
+		if((defaultModuleErrors != null && defaultModuleErrors.size() > 0)
+				|| moduleErrors.size() > 0){
 			
 			List<String> allErrors = new ArrayList<>();
 			

--- a/src/main/java/io/github/vhoyon/vramework/exceptions/ModuleLoaderException.java
+++ b/src/main/java/io/github/vhoyon/vramework/exceptions/ModuleLoaderException.java
@@ -1,0 +1,9 @@
+package io.github.vhoyon.vramework.exceptions;
+
+public class ModuleLoaderException extends Exception {
+	
+	public ModuleLoaderException(String message){
+		super(message);
+	}
+	
+}


### PR DESCRIPTION
(Taken from #9)

- [x] Load the Framework's default modules if not requested against to.
    - this means there could be a Framework constructor with a boolean defaulting to `true`;
- [x] Load any automatic `Module`s placed in `/app.modules.auto.*` using [ClassGraph](https://github.com/classgraph/classgraph).
- [x] Load any additionnal Modules provided via the Framework's constructor.
    - Given only a name (ex. : `Racer`), it would load it in the default directory (`/app.modules.*`);
        - This means that naming it `test.Racer` would search for `/app.modules.test.Racer.java`.
    - Given a path starting with `/` (ex. : `/app.animations.Racer`), it would load the module from the full path provided.

Using Classes instead of potentially destructive Strings. If the application wants to use Strings, they will be able to convert their String to class themselves.

Closes #9