### PR TITLE
Tweak AbstractBotCommand to put a handler on the action method

### DIFF
--- a/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
+++ b/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
@@ -18,6 +18,7 @@ import io.github.vhoyon.vramework.modules.Logger;
 import io.github.vhoyon.vramework.objects.*;
 import io.github.vhoyon.vramework.objects.Request.Parameter;
 import io.github.vhoyon.vramework.res.FrameworkResources;
+import io.github.vhoyon.vramework.utilities.KeyBuilder;
 import io.github.vhoyon.vramework.utilities.TimerManager;
 import io.github.vhoyon.vramework.utilities.formatting.DiscordFormatter;
 import io.github.vhoyon.vramework.utilities.settings.Setting;
@@ -45,7 +46,7 @@ public abstract class AbstractBotCommand extends Translatable implements
 	
 	public static final BufferLevel DEFAULT_BUFFER_LEVEL = BufferLevel.CHANNEL;
 	
-	public static final String TYPING_TIMER_NAME = "TYPING_TIMER";
+	public static final String TYPING_TIMER_NAME = "VRAMEWORK_BOT_TYPING_TIMER";
 	
 	protected AbstractCommandRouter router;
 	
@@ -92,16 +93,25 @@ public abstract class AbstractBotCommand extends Translatable implements
 		
 		if(shouldDisplayTypingIndicator){
 			
-			TimerManager.schedule(TYPING_TIMER_NAME, 7500,
-					() -> getTextContext().sendTyping().queue(),
-					() -> TimerManager.resetTimer(TYPING_TIMER_NAME));
+			TextChannel channel = this.getTextContext();
+			
+			String typingTimerName = KeyBuilder.buildTextChannelObjectKey(
+					channel, TYPING_TIMER_NAME);
+			
+			TimerManager.schedule(typingTimerName, 7500, () -> channel
+					.sendTyping().queue(), () -> TimerManager
+					.resetTimer(typingTimerName));
 			
 		}
 		
 		actions();
 		
-		if(shouldDisplayTypingIndicator)
-			TimerManager.stopTimer(TYPING_TIMER_NAME);
+		if(shouldDisplayTypingIndicator){
+			String typingTimerName = KeyBuilder.buildTextChannelObjectKey(
+					getTextContext(), TYPING_TIMER_NAME);
+			
+			TimerManager.stopTimer(typingTimerName);
+		}
 		
 	}
 	
@@ -753,7 +763,8 @@ public abstract class AbstractBotCommand extends Translatable implements
 	}
 	
 	public void stopTypingIndicator(){
-		TimerManager.stopTimer(TYPING_TIMER_NAME);
+		TimerManager.stopTimer(KeyBuilder.buildTextChannelObjectKey(
+				getTextContext(), TYPING_TIMER_NAME));
 	}
 	
 	public void log(String message){

--- a/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
+++ b/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
@@ -18,6 +18,7 @@ import io.github.vhoyon.vramework.modules.Logger;
 import io.github.vhoyon.vramework.objects.*;
 import io.github.vhoyon.vramework.objects.Request.Parameter;
 import io.github.vhoyon.vramework.res.FrameworkResources;
+import io.github.vhoyon.vramework.utilities.TimerManager;
 import io.github.vhoyon.vramework.utilities.formatting.DiscordFormatter;
 import io.github.vhoyon.vramework.utilities.settings.Setting;
 import io.github.vhoyon.vramework.utilities.settings.SettingRepository;
@@ -43,6 +44,8 @@ public abstract class AbstractBotCommand extends Translatable implements
 		DiscordUtils {
 	
 	public static final BufferLevel DEFAULT_BUFFER_LEVEL = BufferLevel.CHANNEL;
+	
+	public static final String TYPING_TIMER_NAME = "TYPING_TIMER";
 	
 	protected AbstractCommandRouter router;
 	
@@ -81,6 +84,28 @@ public abstract class AbstractBotCommand extends Translatable implements
 		this.isCopy = true;
 		
 	}
+	
+	@Override
+	public void action(){
+		
+		boolean shouldDisplayTypingIndicator = this.displayTypingIndicator();
+		
+		if(shouldDisplayTypingIndicator){
+			
+			TimerManager.schedule(TYPING_TIMER_NAME, 7500,
+					() -> getTextContext().sendTyping().queue(),
+					() -> TimerManager.resetTimer(TYPING_TIMER_NAME));
+			
+		}
+		
+		actions();
+		
+		if(shouldDisplayTypingIndicator)
+			TimerManager.stopTimer(TYPING_TIMER_NAME);
+		
+	}
+	
+	protected abstract void actions();
 	
 	public String getCommandName(){
 		
@@ -721,6 +746,14 @@ public abstract class AbstractBotCommand extends Translatable implements
 		
 		settings.save(settingName, value, onChange);
 		
+	}
+	
+	public boolean displayTypingIndicator(){
+		return true;
+	}
+	
+	public void stopTypingIndicator(){
+		TimerManager.stopTimer(TYPING_TIMER_NAME);
 	}
 	
 	public void log(String message){


### PR DESCRIPTION
This change makes it so that all BotCommands will need to Override the actions() method instead of the action() method to support vramework level features such as Bot Typing indicator.

This change introduces a new abstract method, and is therefore NOT backward compatible - old BotCommand commands will need to adapt to this new change (probably only requiring to add an "s" to the end of their "action()" method override).

While at it, I also added the Typing Indicator with few goodies such as the ability to control if a command should start by having a Typing indicator or not, and to manually stop it (the actual stop takes 10 seconds from when it was refreshed last, but disappears as soon as a message is sent - until refreshed. Once the new `actions()` method is over, the call to stop the Bot Typing Indicator is automatically stopped. Closes #10