### PR TITLE
Update Buffer to add custom implementation for saving objects

### DIFF
--- a/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
+++ b/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractBotCommand.java
@@ -193,12 +193,12 @@ public abstract class AbstractBotCommand extends Translatable implements
 		return getBuffer().push(object, associatedName, getKey(level));
 	}
 	
-	public Object getMemory(String associatedName) throws NullPointerException{
+	public <E> E getMemory(String associatedName) throws IllegalStateException{
 		return getMemory(associatedName, DEFAULT_BUFFER_LEVEL);
 	}
 	
-	public Object getMemory(String associatedName, BufferLevel level)
-			throws NullPointerException{
+	public <E> E getMemory(String associatedName, BufferLevel level)
+			throws IllegalStateException{
 		return getBuffer().get(associatedName, getKey(level));
 	}
 	

--- a/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractCommandRouter.java
+++ b/src/main/java/io/github/vhoyon/vramework/abstracts/AbstractCommandRouter.java
@@ -40,7 +40,7 @@ public abstract class AbstractCommandRouter extends Thread implements Utils,
 			setDictionary((Dictionary)bufferedDict);
 			
 		}
-		catch(NullPointerException e){
+		catch(IllegalStateException e){
 			
 			setDictionary(new Dictionary());
 			

--- a/src/main/java/io/github/vhoyon/vramework/interfaces/BufferImplementation.java
+++ b/src/main/java/io/github/vhoyon/vramework/interfaces/BufferImplementation.java
@@ -1,0 +1,17 @@
+package io.github.vhoyon.vramework.interfaces;
+
+public interface BufferImplementation<E> {
+	
+	E getMemory();
+	
+	boolean store(String key, Object object);
+	
+	Object retrieve(String key) throws IllegalStateException;
+	
+	boolean has(String key);
+	
+	boolean remove(String key);
+	
+	void empty();
+	
+}

--- a/src/main/java/io/github/vhoyon/vramework/objects/Buffer.java
+++ b/src/main/java/io/github/vhoyon/vramework/objects/Buffer.java
@@ -1,27 +1,53 @@
 package io.github.vhoyon.vramework.objects;
 
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 
+import io.github.vhoyon.vramework.interfaces.BufferImplementation;
 import io.github.vhoyon.vramework.interfaces.Utils;
 
 public class Buffer {
 	
 	private static Buffer buffer;
 	
-	private HashMap<String, Object> memory;
-	private HashMap<Class<?>, Object> singletonMemory;
+	private BufferImplementation memoryImpl;
+	private BufferImplementation singletonImpl;
 	
-	private Buffer(){
-		memory = new HashMap<>();
-		singletonMemory = new HashMap<>();
-	}
+	private Buffer(){}
 	
 	public static Buffer get(){
 		if(buffer == null)
 			buffer = new Buffer();
 		
 		return buffer;
+	}
+	
+	protected final BufferImplementation getMemoryImpl(){
+		if(this.memoryImpl == null)
+			setMemoryImplementation(new DefaultBufferImplementation());
+		
+		return this.memoryImpl;
+	}
+	
+	protected final BufferImplementation getSingletonMemoryImpl(){
+		if(this.singletonImpl == null)
+			setSingletonMemoryImplementation(new DefaultBufferImplementation());
+		
+		return this.singletonImpl;
+	}
+	
+	public static void setMemoryImplementation(
+			BufferImplementation implementation){
+		Buffer.get().memoryImpl = implementation;
+	}
+	
+	public static void setSingletonMemoryImplementation(
+			BufferImplementation implementation){
+		Buffer.get().singletonImpl = implementation;
+	}
+	
+	public static void setImplementation(BufferImplementation implementation){
+		Buffer.setMemoryImplementation(implementation);
+		Buffer.setSingletonMemoryImplementation(implementation);
 	}
 	
 	public static <E> E getSingleton(Class<E> desiredClass,
@@ -33,10 +59,13 @@ public class Buffer {
 					"The desiredClass parameter cannot be null!");
 		}
 		
+		String classKey = desiredClass.getName();
+		
 		Buffer buffer = Buffer.get();
 		
-		if(buffer.singletonMemory.containsKey(desiredClass)){
-			return (E)buffer.singletonMemory.get(desiredClass);
+		if(buffer.getSingletonMemoryImpl().has(classKey)){
+			//noinspection unchecked
+			return (E)buffer.getSingletonMemoryImpl().retrieve(classKey);
 		}
 		else{
 			
@@ -51,7 +80,7 @@ public class Buffer {
 						e);
 			}
 			
-			buffer.singletonMemory.put(desiredClass, newClassSingleton);
+			buffer.getSingletonMemoryImpl().store(classKey, newClassSingleton);
 			
 			return newClassSingleton;
 			
@@ -60,11 +89,27 @@ public class Buffer {
 	}
 	
 	public static <E> E removeSingleton(Class<E> singletonClass){
-		return (E)Buffer.get().singletonMemory.remove(singletonClass);
+		
+		Buffer buffer = Buffer.get();
+		
+		String classKey = singletonClass.getName();
+		
+		if(!buffer.getSingletonMemoryImpl().has(classKey))
+			return null;
+		
+		//noinspection unchecked
+		E singletonInstance = (E)buffer.getSingletonMemoryImpl().retrieve(
+				classKey);
+		
+		buffer.getSingletonMemoryImpl().remove(classKey);
+		
+		return singletonInstance;
+		
 	}
 	
 	public static boolean hasSingleton(Class<?> singletonClass){
-		return Buffer.get().singletonMemory.containsKey(singletonClass);
+		return Buffer.get().getSingletonMemoryImpl()
+				.has(singletonClass.getName());
 	}
 	
 	public boolean push(Object object, String associatedName, String key){
@@ -76,17 +121,11 @@ public class Buffer {
 	}
 	
 	public boolean push(Object object, String fullKey){
-		
-		boolean isNewObject = !memory.containsKey(fullKey);
-		
-		memory.put(fullKey, object);
-		
-		return isNewObject;
-		
+		return this.getMemoryImpl().store(fullKey, object);
 	}
 	
-	public Object get(String associatedName, String key)
-			throws NullPointerException{
+	public <E> E get(String associatedName, String key)
+			throws IllegalStateException{
 		
 		String objectKey = Utils.buildKey(key, associatedName);
 		
@@ -94,18 +133,15 @@ public class Buffer {
 		
 	}
 	
-	public Object get(String fullKey) throws NullPointerException{
-		
-		boolean hasObject = memory.containsKey(fullKey);
-		
-		if(!hasObject){
-			throw new NullPointerException("No object with the key \""
+	public <E> E get(String fullKey) throws IllegalStateException{
+		try{
+			//noinspection unchecked
+			return (E)this.getMemoryImpl().retrieve(fullKey);
+		}
+		catch(IllegalStateException e){
+			throw new IllegalStateException("No object with the key \""
 					+ fullKey + "\" was found in the Buffer.");
 		}
-		else{
-			return memory.get(fullKey);
-		}
-		
 	}
 	
 	public boolean remove(String associatedName, String key){
@@ -117,21 +153,15 @@ public class Buffer {
 	}
 	
 	public boolean remove(String fullKey){
-		
-		boolean hasRemovedObject = memory.containsKey(fullKey);
-		
-		memory.remove(fullKey);
-		
-		return hasRemovedObject;
-		
+		return this.getMemoryImpl().remove(fullKey);
 	}
 	
 	public void emptyMemory(){
-		memory = new HashMap<>();
+		this.getMemoryImpl().empty();
 	}
 	
 	public boolean has(String key){
-		return this.memory.containsKey(key);
+		return this.getMemoryImpl().has(key);
 	}
 	
 }

--- a/src/main/java/io/github/vhoyon/vramework/objects/DefaultBufferImplementation.java
+++ b/src/main/java/io/github/vhoyon/vramework/objects/DefaultBufferImplementation.java
@@ -1,0 +1,60 @@
+package io.github.vhoyon.vramework.objects;
+
+import java.util.HashMap;
+
+import io.github.vhoyon.vramework.interfaces.BufferImplementation;
+
+public class DefaultBufferImplementation implements
+		BufferImplementation<HashMap<String, Object>> {
+	
+	private HashMap<String, Object> memory;
+	
+	@Override
+	public HashMap<String, Object> getMemory(){
+		if(this.memory == null)
+			this.memory = new HashMap<>();
+		
+		return this.memory;
+	}
+	
+	@Override
+	public boolean store(String key, Object object){
+		boolean isNewObject = this.has(key);
+		
+		this.getMemory().put(key, object);
+		
+		return isNewObject;
+	}
+	
+	@Override
+	public Object retrieve(String key) throws IllegalStateException{
+		boolean hasObject = this.has(key);
+		
+		if(!hasObject){
+			throw new IllegalStateException();
+		}
+		else{
+			return this.getMemory().get(key);
+		}
+	}
+	
+	@Override
+	public boolean has(String key){
+		return this.getMemory().containsKey(key);
+	}
+	
+	@Override
+	public boolean remove(String key){
+		boolean hasRemovedObject = this.getMemory().containsKey(key);
+		
+		this.getMemory().remove(key);
+		
+		return hasRemovedObject;
+	}
+	
+	@Override
+	public void empty(){
+		this.memory = null;
+	}
+	
+}


### PR DESCRIPTION
A `DefaultBufferImplementation` is used as fallback if an implementation wasn't specified prior to the usage of the Buffer methods. This implementation uses a `HashMap` to store data in the memory of the program.

Closes #35